### PR TITLE
Give core project a meaningful name in Android Studio

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
-ViroCore
-=====================
+# ViroCore
+
+[Chat](https://discord.gg/WWFwSQdCyF)
 
 ViroCore is SceneKit for Android, a 3D framework for developers to build immersive applications using Java. ViroCore combines a high-performance rendering engine with a descriptive API for creating 3D, AR, and VR apps. While lower-level APIs like OpenGL require you to precisely implement complex rendering algorithms, ViroCore requires only high-level scene descriptions, and code for the interactivity and animations you want your application to perform.
 

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -1,1 +1,3 @@
+rootProject.name = 'ViroCORE'
+
 include ':app', ':libs:gvr', ':libs:arcore', ':renderertest', ':memoryleaktest', ':virocore', ':viroreact', ':viroar', ':releasetest', ':nativetest'


### PR DESCRIPTION
It's about to change this name 
![image](https://user-images.githubusercontent.com/3314607/98907359-ff448980-24be-11eb-8691-91143fcf8d3a.png)

When every repo is called `android` , you don't know which one it is